### PR TITLE
Feature camera class

### DIFF
--- a/WebARKit/CMakeLists.txt
+++ b/WebARKit/CMakeLists.txt
@@ -33,6 +33,7 @@ ${PARENT_DIR}/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/
 ${PARENT_DIR}/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking//WebARKitEnums.h
 ${PARENT_DIR}/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
 ${PARENT_DIR}/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitUtils.h
+${PARENT_DIR}/include/WebARKitCamera.h
 ${PARENT_DIR}/include/WebARKitLog.h
 ${PARENT_DIR}/include/WebARKitManager.h
 )
@@ -40,6 +41,7 @@ ${PARENT_DIR}/include/WebARKitManager.h
 set(SOURCE 
 ${PARENT_DIR}/WebARKitTrackers/WebARKitOpticalTracking/WebARKitConfig.cpp
 ${PARENT_DIR}/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+${PARENT_DIR}/WebARKitCamera.cpp
 ${PARENT_DIR}/WebARKitLog.cpp
 ${PARENT_DIR}/WebARKitManager.cpp
 )

--- a/WebARKit/WebARKitCamera.cpp
+++ b/WebARKit/WebARKitCamera.cpp
@@ -1,0 +1,21 @@
+#include <cmath>
+#include <algorithm>
+#include <WebARKitCamera.h>
+
+namespace webarkit {
+    WebARKitCamera::WebARKitCamera() : xsize(-1), ysize(-1), diagonal_fov_degrees(70.0) {
+         cmat = cv::Mat.zeros(3, 3, CV_64FC1);
+    }
+
+    WebARKitCamera::~WebARKitCamera() {
+    }
+
+    bool WebARKitCamera::setup() {
+        //diagonal_image_size = (w ** 2.0 + h ** 2.0) ** 0.5
+        diagonal_image_size = std::pow(std::pow(xsize, 2.0) + std::pow(ysize, 2.0), 0.5);
+        /*diagonal_fov_radians = \
+            diagonal_fov_degrees * math.pi / 180.0*/
+        diagonal_fov_radians = diagonal_fov_degrees * M_PI / 180.0;
+        focal_length = 0.5 * diagonal_image_size / std::tan(0.5 * diagonal_fov_radians);
+    };
+}

--- a/WebARKit/WebARKitCamera.cpp
+++ b/WebARKit/WebARKitCamera.cpp
@@ -13,10 +13,8 @@ bool WebARKitCamera::setupCamera(int width, int height) {
     }
     xsize = width;
     ysize = height;
-    // simple routine to calculate focal length from diagonal field of view, and convert to camera matrix.
-    diagonal_image_size = std::pow(std::pow(xsize, 2.0) + std::pow(ysize, 2.0), 0.5);
-    diagonal_fov_radians = diagonal_fov_degrees * m_pi / 180.0;
-    focal_length = 0.5 * diagonal_image_size / std::tan(0.5 * diagonal_fov_radians);
+
+    setFocalLength(xsize, ysize);
 
     cmat.at(0) = focal_length;
     cmat.at(2) = 0.5 * xsize;
@@ -41,5 +39,14 @@ std::array<double, 9> WebARKitCamera::getCameraData() const {
 
 std::array<double, 6> WebARKitCamera::getDistortionCoefficients() const {
    return kc;
+}
+
+void WebARKitCamera::setFocalLength(int width, int height) {
+    double diagonal_image_size;
+    double diagonal_fov_radians;
+     // simple routine to calculate focal length from diagonal field of view, and convert to camera matrix.
+    diagonal_image_size = std::pow(std::pow(width, 2.0) + std::pow(height, 2.0), 0.5);
+    diagonal_fov_radians = diagonal_fov_degrees * m_pi / 180.0;
+    focal_length = 0.5 * diagonal_image_size / std::tan(0.5 * diagonal_fov_radians);
 }
 } // namespace webarkit

--- a/WebARKit/WebARKitCamera.cpp
+++ b/WebARKit/WebARKitCamera.cpp
@@ -33,4 +33,12 @@ void WebARKitCamera::printSettings() {
     printf("                          [%.2f  %.2f %.2f]\n", cmat[6], cmat[7], cmat[8]);
     printf("WebARKit: kc = [%.4f %.4f %.4f %.4f %.4f %.4f]\n", kc[0], kc[1], kc[2], kc[3], kc[4], kc[5]);
 };
+
+std::array<double, 9> WebARKitCamera::getCameraData() const {
+    return cmat;
+}
+
+std::array<double, 6> WebARKitCamera::getDistortionCoefficients() const {
+   return kc;
+}
 } // namespace webarkit

--- a/WebARKit/WebARKitCamera.cpp
+++ b/WebARKit/WebARKitCamera.cpp
@@ -1,21 +1,36 @@
-#include <cmath>
-#include <algorithm>
 #include <WebARKitCamera.h>
+#include <WebARKitTrackers/WebARKitOpticalTracking/WebARKitConfig.h>
 
 namespace webarkit {
-    WebARKitCamera::WebARKitCamera() : xsize(-1), ysize(-1), diagonal_fov_degrees(70.0) {
-         cmat = cv::Mat.zeros(3, 3, CV_64FC1);
-    }
+WebARKitCamera::WebARKitCamera() : xsize(-1), ysize(-1), diagonal_fov_degrees(70.0) { cmat.fill(0.0); }
 
-    WebARKitCamera::~WebARKitCamera() {
-    }
+WebARKitCamera::~WebARKitCamera() {}
 
-    bool WebARKitCamera::setup() {
-        //diagonal_image_size = (w ** 2.0 + h ** 2.0) ** 0.5
-        diagonal_image_size = std::pow(std::pow(xsize, 2.0) + std::pow(ysize, 2.0), 0.5);
-        /*diagonal_fov_radians = \
-            diagonal_fov_degrees * math.pi / 180.0*/
-        diagonal_fov_radians = diagonal_fov_degrees * M_PI / 180.0;
-        focal_length = 0.5 * diagonal_image_size / std::tan(0.5 * diagonal_fov_radians);
-    };
-}
+bool WebARKitCamera::setupCamera(int width, int height) {
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+    xsize = width;
+    ysize = height;
+    // simple routine to calculate focal length from diagonal field of view, and convert to camera matrix.
+    diagonal_image_size = std::pow(std::pow(xsize, 2.0) + std::pow(ysize, 2.0), 0.5);
+    diagonal_fov_radians = diagonal_fov_degrees * m_pi / 180.0;
+    focal_length = 0.5 * diagonal_image_size / std::tan(0.5 * diagonal_fov_radians);
+
+    cmat.at(0) = focal_length;
+    cmat.at(2) = 0.5 * xsize;
+    cmat.at(4) = focal_length;
+    cmat.at(5) = 0.5 * ysize;
+    cmat.at(8) = 1.0;
+    kc.fill(0.0);
+    return true;
+};
+
+void WebARKitCamera::printSettings() {
+    printf("WebARKit: Camera Size %d , %d\n", xsize, ysize);
+    printf("WebARKit: camera matrix = [%.2f  %.2f %.2f]\n", cmat[0], cmat[1], cmat[2]);
+    printf("                          [%.2f  %.2f %.2f]\n", cmat[3], cmat[4], cmat[5]);
+    printf("                          [%.2f  %.2f %.2f]\n", cmat[6], cmat[7], cmat[8]);
+    printf("WebARKit: kc = [%.4f %.4f %.4f %.4f %.4f %.4f]\n", kc[0], kc[1], kc[2], kc[3], kc[4], kc[5]);
+};
+} // namespace webarkit

--- a/WebARKit/WebARKitCamera.cpp
+++ b/WebARKit/WebARKitCamera.cpp
@@ -1,4 +1,5 @@
 #include <WebARKitCamera.h>
+#include <WebARKitLog.h>
 #include <WebARKitTrackers/WebARKitOpticalTracking/WebARKitConfig.h>
 
 namespace webarkit {
@@ -27,11 +28,11 @@ bool WebARKitCamera::setupCamera(int width, int height) {
 };
 
 void WebARKitCamera::printSettings() {
-    printf("WebARKit: Camera Size %d , %d\n", xsize, ysize);
-    printf("WebARKit: camera matrix = [%.2f  %.2f %.2f]\n", cmat[0], cmat[1], cmat[2]);
-    printf("                          [%.2f  %.2f %.2f]\n", cmat[3], cmat[4], cmat[5]);
-    printf("                          [%.2f  %.2f %.2f]\n", cmat[6], cmat[7], cmat[8]);
-    printf("WebARKit: kc = [%.4f %.4f %.4f %.4f %.4f %.4f]\n", kc[0], kc[1], kc[2], kc[3], kc[4], kc[5]);
+    WEBARKIT_LOGi("WebARKit: Camera Size %d , %d\n", xsize, ysize);
+    WEBARKIT_LOGi("WebARKit: camera matrix = [%.2f  %.2f %.2f]\n", cmat[0], cmat[1], cmat[2]);
+    WEBARKIT_LOGi("                          [%.2f  %.2f %.2f]\n", cmat[3], cmat[4], cmat[5]);
+    WEBARKIT_LOGi("                          [%.2f  %.2f %.2f]\n", cmat[6], cmat[7], cmat[8]);
+    WEBARKIT_LOGi("WebARKit: kc = [%.4f %.4f %.4f %.4f %.4f %.4f]\n", kc[0], kc[1], kc[2], kc[3], kc[4], kc[5]);
 };
 
 std::array<double, 9> WebARKitCamera::getCameraData() const {

--- a/WebARKit/WebARKitManager.cpp
+++ b/WebARKit/WebARKitManager.cpp
@@ -18,7 +18,7 @@ std::string WebARKitManager::getWebARKitVersion() {
     return versionString;
 }
 
-bool WebARKitManager::initialiseBase(webarkit::TRACKER_TYPE trackerType) {
+bool WebARKitManager::initialiseBase(webarkit::TRACKER_TYPE trackerType, int frameWidth, int frameHeight) {
     WEBARKIT_LOGd("WebARKItManager::initialiseBase(...)\n");
     if (state != NOTHING_INITIALISED) {
         WEBARKIT_LOGe("Initialise called while already initialised. Will finish first.\n");
@@ -33,7 +33,7 @@ bool WebARKitManager::initialiseBase(webarkit::TRACKER_TYPE trackerType) {
     m_trackerType = trackerType;
 
     m_tracker = std::make_shared<webarkit::WebARKitTracker>();
-    m_tracker->initialize(m_trackerType);
+    m_tracker->initialize(m_trackerType, frameWidth, frameHeight);
 
     state = BASE_INITIALISED;
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitConfig.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitConfig.cpp
@@ -13,6 +13,7 @@ extern const double featureDetectPyramidLevel =
     1.05f; ///> Scale factor applied to image pyramid to determine image to perform feature matching upon.
 extern const int featureBorder = 8;
 extern const cv::Size blurSize(3, 3);
+extern const double m_pi = 3.14159265358979323846;
 extern const std::string WEBARKIT_HEADER_VERSION_STRING = "1.0.0";
 /*@
     The MAJOR version number defines non-backwards compatible

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -10,7 +10,7 @@ class WebARKitTracker::WebARKitTrackerImpl {
           minNumMatches(MIN_NUM_MATCHES), _nn_match_ratio(0.7f){};
     ~WebARKitTrackerImpl() = default;
 
-    void initialize(webarkit::TRACKER_TYPE trackerType) {
+    void initialize(webarkit::TRACKER_TYPE trackerType, int frameWidth, int frameHeight) {
         setDetectorType(trackerType);
         if (trackerType == webarkit::TEBLID_TRACKER) {
             _nn_match_ratio = TEBLID_NN_MATCH_RATIO;
@@ -22,6 +22,8 @@ class WebARKitTracker::WebARKitTrackerImpl {
             _nn_match_ratio = DEFAULT_NN_MATCH_RATIO;
             minNumMatches = 15;
         }
+        _camera->setupCamera(frameWidth, frameHeight);
+        _camera->printSettings();
     }
 
     void initTracker(uchar* refData, size_t refCols, size_t refRows) {
@@ -288,6 +290,8 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
     bool initialized;
 
+    WebARKitCamera* _camera = new WebARKitCamera();
+
   private:
     std::vector<double> output; // 9 from homography matrix, 8 from warped corners*/
 
@@ -339,7 +343,7 @@ WebARKitTracker::WebARKitTracker(WebARKitTracker&&) = default; // copy construct
 
 WebARKitTracker& WebARKitTracker::operator=(WebARKitTracker&&) = default; // move assignment operator
 
-void WebARKitTracker::initialize(webarkit::TRACKER_TYPE trackerType) { _trackerImpl->initialize(trackerType); }
+void WebARKitTracker::initialize(webarkit::TRACKER_TYPE trackerType, int frameWidth, int frameHeight) { _trackerImpl->initialize(trackerType, frameWidth, frameHeight); }
 
 void WebARKitTracker::initTracker(uchar* refData, size_t refCols, size_t refRows) {
     _trackerImpl->initTracker(refData, refCols, refRows);

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -7,7 +7,10 @@ class WebARKitTracker::WebARKitTrackerImpl {
   public:
     WebARKitTrackerImpl()
         : corners(4), initialized(false), output(17, 0.0), _valid(false), _isDetected(false), numMatches(0),
-          minNumMatches(MIN_NUM_MATCHES), _nn_match_ratio(0.7f){};
+          minNumMatches(MIN_NUM_MATCHES), _nn_match_ratio(0.7f){
+            m_camMatrix = cv::Mat();
+            m_distortionCoeff = cv::Mat();
+          };
     ~WebARKitTrackerImpl() = default;
 
     void initialize(webarkit::TRACKER_TYPE trackerType, int frameWidth, int frameHeight) {
@@ -24,6 +27,8 @@ class WebARKitTracker::WebARKitTrackerImpl {
         }
         _camera->setupCamera(frameWidth, frameHeight);
         _camera->printSettings();
+        m_camMatrix = cv::Mat(3,3, CV_64FC1, _camera->getCameraData().data());
+        m_distortionCoeff = cv::Mat(6, 1, CV_64FC1, _camera->getDistortionCoefficients().data());
     }
 
     void initTracker(uchar* refData, size_t refCols, size_t refRows) {
@@ -291,6 +296,9 @@ class WebARKitTracker::WebARKitTrackerImpl {
     bool initialized;
 
     WebARKitCamera* _camera = new WebARKitCamera();
+
+    cv::Mat m_camMatrix;
+    cv::Mat m_distortionCoeff;
 
   private:
     std::vector<double> output; // 9 from homography matrix, 8 from warped corners*/

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitConfig.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitConfig.h
@@ -20,6 +20,7 @@ extern const cv::TermCriteria termcrit;
 extern const double featureDetectPyramidLevel; ///> Scale factor applied to image pyramid to determine image to perform feature matching upon.
 extern const int featureBorder;
 extern const cv::Size blurSize;
+extern const double m_pi;
 extern const std::string WEBARKIT_HEADER_VERSION_STRING;
 extern const int WEBARKIT_HEADER_VERSION_MAJOR;
 extern const int WEBARKIT_HEADER_VERSION_MINOR;

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
@@ -3,6 +3,7 @@
 
 #include "WebARKitEnums.h"
 #include <WebARKitLog.h>
+#include <WebARKitCamera.h>
 #include <opencv2/xfeatures2d.hpp>
 
 namespace webarkit {
@@ -17,7 +18,7 @@ class WebARKitTracker {
 
     WebARKitTracker& operator=(WebARKitTracker&&);
 
-    void initialize(webarkit::TRACKER_TYPE trackerType);
+    void initialize(webarkit::TRACKER_TYPE trackerType, int frameWidth, int frameHeight);
 
     void initTracker(uchar* refData, size_t refCols, size_t refRows);
 

--- a/WebARKit/include/WebARKitCamera.h
+++ b/WebARKit/include/WebARKitCamera.h
@@ -1,27 +1,27 @@
 #ifndef WEBARKITCAMERA_H
 #define WEBARKITCAMERA_H
 
-#include <opencv2/core.hpp>
+#include <array>
 
 namespace webarkit {
-    class WebARKitCamera {
-        public:
-            WebARKitCamera();
-            ~WebARKitCamera();
+class WebARKitCamera {
+  public:
+    WebARKitCamera();
+    ~WebARKitCamera();
 
-            bool setup();
+    bool setupCamera(int width, int height);
+    void printSettings();
 
-            int xsize, ysize;
-            cv::Mat cmat(3, 3, CV_64FC1);
-            float kc[6];
-        private:
-            float focal_length;
-            float diagonal_image_size;
-            float diagonal_fov_degrees;
-            float diagonal_fov_radians;
+    int xsize, ysize;
+    std::array<double, 9> cmat;
+    std::array<double, 6> kc;
 
-    };
-}
-
+  private:
+    double focal_length;
+    double diagonal_image_size;
+    double diagonal_fov_degrees;
+    double diagonal_fov_radians;
+};
+} // namespace webarkit
 
 #endif // WEBARKITCAMERA_H

--- a/WebARKit/include/WebARKitCamera.h
+++ b/WebARKit/include/WebARKitCamera.h
@@ -10,13 +10,17 @@ class WebARKitCamera {
     ~WebARKitCamera();
 
     bool setupCamera(int width, int height);
+
     void printSettings();
 
+    std::array<double, 9> getCameraData() const;
+
+    std::array<double, 6> getDistortionCoefficients() const;
+
+  private:
     int xsize, ysize;
     std::array<double, 9> cmat;
     std::array<double, 6> kc;
-
-  private:
     double focal_length;
     double diagonal_image_size;
     double diagonal_fov_degrees;

--- a/WebARKit/include/WebARKitCamera.h
+++ b/WebARKit/include/WebARKitCamera.h
@@ -1,0 +1,27 @@
+#ifndef WEBARKITCAMERA_H
+#define WEBARKITCAMERA_H
+
+#include <opencv2/core.hpp>
+
+namespace webarkit {
+    class WebARKitCamera {
+        public:
+            WebARKitCamera();
+            ~WebARKitCamera();
+
+            bool setup();
+
+            int xsize, ysize;
+            cv::Mat cmat(3, 3, CV_64FC1);
+            float kc[6];
+        private:
+            float focal_length;
+            float diagonal_image_size;
+            float diagonal_fov_degrees;
+            float diagonal_fov_radians;
+
+    };
+}
+
+
+#endif // WEBARKITCAMERA_H

--- a/WebARKit/include/WebARKitCamera.h
+++ b/WebARKit/include/WebARKitCamera.h
@@ -17,14 +17,16 @@ class WebARKitCamera {
 
     std::array<double, 6> getDistortionCoefficients() const;
 
+    double getFocalLength() const { return focal_length; }
+
   private:
     int xsize, ysize;
     std::array<double, 9> cmat;
     std::array<double, 6> kc;
     double focal_length;
-    double diagonal_image_size;
     double diagonal_fov_degrees;
-    double diagonal_fov_radians;
+
+    void setFocalLength(int width, int height);
 };
 } // namespace webarkit
 

--- a/WebARKit/include/WebARKitManager.h
+++ b/WebARKit/include/WebARKitManager.h
@@ -79,7 +79,7 @@ class WebARKitManager {
      * Start trackable management so trackables can be added and removed.
      * @return       true if initialisation was OK, false if an error occured.
      */
-    bool initialiseBase(webarkit::TRACKER_TYPE trackerType);
+    bool initialiseBase(webarkit::TRACKER_TYPE trackerType, int frameWidth, int frameHeight);
 
     /**
      * Return the current tracker object.

--- a/tests/webarkit_test.cc
+++ b/tests/webarkit_test.cc
@@ -78,6 +78,7 @@ TEST(WebARKitCameraTest, TestCamera) {
   EXPECT_EQ(camera_mat[4], 571.25920269684582);
   EXPECT_EQ(camera_mat[5], 240.0);
   EXPECT_EQ(camera_mat[8], 1.0);
+  EXPECT_EQ(camera.getFocalLength(), 571.25920269684582);
   camera.printSettings();
 }
 

--- a/tests/webarkit_test.cc
+++ b/tests/webarkit_test.cc
@@ -66,7 +66,7 @@ TEST(WebARKitTest, InitialiseBaseAkazeTest) {
   // Create a WebARKitManager object
   webarkit::WebARKitManager manager;
   // Check if the WebARKitManager initialisation is successful
-  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER));
+  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER, 640, 480));
 }
 
 // Check WebARKitManager initialisation.
@@ -74,7 +74,7 @@ TEST(WebARKitTest, InitialiseBaseFreakTest) {
   // Create a WebARKitManager object
   webarkit::WebARKitManager manager;
   // Check if the WebARKitManager initialisation is successful
-  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::FREAK_TRACKER));
+  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::FREAK_TRACKER, 640, 480));
 }
 
 // Check WebARKitManager initialisation.
@@ -82,7 +82,7 @@ TEST(WebARKitTest, InitialiseBaseOrbTest) {
   // Create a WebARKitManager object
   webarkit::WebARKitManager manager;
   // Check if the WebARKitManager initialisation is successful
-  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::ORB_TRACKER));
+  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::ORB_TRACKER, 640, 480));
 }
 
 // Check WebARKitManager initialisation.
@@ -90,7 +90,7 @@ TEST(WebARKitTest, InitialiseBaseTeblidTest) {
   // Create a WebARKitManager object
   webarkit::WebARKitManager manager;
   // Check if the WebARKitManager initialisation is successful
-  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::TEBLID_TRACKER));
+  EXPECT_TRUE(manager.initialiseBase(webarkit::TRACKER_TYPE::TEBLID_TRACKER, 640, 480));
 }
 
 // Check WebARKit version
@@ -98,7 +98,7 @@ TEST(WebARKitTest, CheckWebARKitVersion) {
   // Create a WebARKitManager object
   webarkit::WebARKitManager manager;
   // Init the manager with the Akaze tracker
-  manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER);
+  manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER, 640, 480);
   // Check if the WebARKit version is correct
   EXPECT_STREQ(manager.getWebARKitVersion().c_str(), "1.0.0");
 }
@@ -107,7 +107,7 @@ TEST(WebARKitTest, InitTrackerTest) {
   // Create a WebARKitManager object
   webarkit::WebARKitManager manager;
   // Init the manager with the Akaze tracker
-  manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER);
+  manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER, 640, 480);
   // Load the test image
   cv::Mat image = cv::imread("pinball.jpg");
 
@@ -135,7 +135,7 @@ TEST(WebARKitTest, CheckShutDown) {
   // Create a WebARKitManager object
   webarkit::WebARKitManager manager;
   // Init the manager with the Akaze tracker
-  manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER);
+  manager.initialiseBase(webarkit::TRACKER_TYPE::AKAZE_TRACKER, 640, 480);
   // Check if the WebARKit went down successfully
   EXPECT_TRUE(manager.shutdown());
 }

--- a/tests/webarkit_test.cc
+++ b/tests/webarkit_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <WebARKitManager.h>
 #include <WebARKitTrackers/WebARKitOpticalTracking/WebARKitEnums.h>
+#include <WebARKitCamera.h>
 #include <opencv2/imgcodecs.hpp>
 
 class WebARKitEnumTest : public testing::TestWithParam<std::tuple<webarkit::TRACKER_TYPE, webarkit::ColorSpace>> {};
@@ -59,6 +60,25 @@ TEST(WebARKitConfigTest, TestBlurSize) {
   cv::Size expected_blur_size(3, 3);
   EXPECT_EQ(expected_blur_size.width, blurSize.width);
   EXPECT_EQ(expected_blur_size.height, blurSize.height);
+}
+
+TEST(WebARKitConfigTest, TestPIConstant) {
+  double internal_m_pi = 3.14159265358979323846;
+  EXPECT_EQ(internal_m_pi, m_pi);
+}
+
+TEST(WebARKitCameraTest, TestCamera) {
+  int width = 640;
+  int height = 480;
+  webarkit::WebARKitCamera camera;
+  EXPECT_TRUE(camera.setupCamera(width, height));
+  std::array<double, 9> camera_mat = camera.getCameraData();
+  EXPECT_EQ(camera_mat[0], 571.25920269684582);
+  EXPECT_EQ(camera_mat[2], 320.0);
+  EXPECT_EQ(camera_mat[4], 571.25920269684582);
+  EXPECT_EQ(camera_mat[5], 240.0);
+  EXPECT_EQ(camera_mat[8], 1.0);
+  camera.printSettings();
 }
 
 // Check WebARKitManager initialisation.


### PR DESCRIPTION
# WebARKitCamera class
As mentioned in issue #21 i will implement a basic Camera class because it is necessary for the PnP computation retrieve the camera Matrix and the distortion coefficients.
For now it will calculate the camera matrix based on the width and height inputs of the camera (see setupCamera ) . This follow the OpenCV convention a matrix 3x3: 
```
//camera matrix
[[fc, 0.0, cx],
 [0.0, fc, cy],
 [0.0, 0.0, 1.0]]
```
where `fc` is the `focal length` and `cx = width/2` and `cy height/2`.
Read for more in this [opencv tutorial](https://docs.opencv.org/4.x/d4/d94/tutorial_camera_calibration.html).
The class also create distorion coefficients, 6 values, but we left to zeros.

I have implemented these member methods:
**public**:
- **setupCamera()**
- **printCameraSettings()**
- **getCameraData()**
- **getDistortionCoefficients()**
- **getFocalLength()**

**private**:
- **setFocalLength()**


In the future i will implement other methods: to load a calibration file and other utilities. I want to develop only the minimum for now: as said before, we neeed a camera matrix to compute the pose matrix with the PnP algorithm.
Tests are provided in the **tests/webarkit_test.cpp** file.
`