### PR TITLE
Feature improves transmatrix

### DIFF
--- a/WebARKit/WebARKitManager.cpp
+++ b/WebARKit/WebARKitManager.cpp
@@ -79,7 +79,7 @@ bool WebARKitManager::shutdown() {
     return true;
 };
 
-void WebARKitManager::processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, bool enableBlur) {
+void WebARKitManager::processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType, bool enableBlur) {
     WEBARKIT_LOGd("WebARKitManager::processFrameData(...)\n");
     if (state < WAITING_FOR_VIDEO) {
         WEBARKIT_LOGe("processFrameData called without init the tracker. Call first initTracker.\n");
@@ -88,7 +88,7 @@ void WebARKitManager::processFrameData(uchar* frameData, size_t frameCols, size_
         WEBARKIT_LOGe("Error initialising processFrameData.\n");
         //return false;
     }
-  m_tracker->processFrameData(frameData, frameCols, frameRows, colorSpace, enableBlur);
+  m_tracker->processFrameData(frameData, frameCols, frameRows, colorSpace, blurType, enableBlur);
   state = DETECTION_RUNNING;
   WEBARKIT_LOGd("WebARKitManager::processFrameData() done\n");
 }

--- a/WebARKit/WebARKitManager.cpp
+++ b/WebARKit/WebARKitManager.cpp
@@ -79,7 +79,7 @@ bool WebARKitManager::shutdown() {
     return true;
 };
 
-void WebARKitManager::processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType, bool enableBlur) {
+void WebARKitManager::processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType) {
     WEBARKIT_LOGd("WebARKitManager::processFrameData(...)\n");
     if (state < WAITING_FOR_VIDEO) {
         WEBARKIT_LOGe("processFrameData called without init the tracker. Call first initTracker.\n");
@@ -88,7 +88,7 @@ void WebARKitManager::processFrameData(uchar* frameData, size_t frameCols, size_
         WEBARKIT_LOGe("Error initialising processFrameData.\n");
         //return false;
     }
-  m_tracker->processFrameData(frameData, frameCols, frameRows, colorSpace, blurType, enableBlur);
+  m_tracker->processFrameData(frameData, frameCols, frameRows, colorSpace, blurType);
   state = DETECTION_RUNNING;
   WEBARKIT_LOGd("WebARKitManager::processFrameData() done\n");
 }

--- a/WebARKit/WebARKitPattern.cpp
+++ b/WebARKit/WebARKitPattern.cpp
@@ -53,6 +53,18 @@ void WebARKitPatternTrackingInfo::getTrackablePose(cv::Mat& pose) {
     memcpy(transMat, poseOut.ptr<float>(0), 3*4*sizeof(float));
 }
 
+void WebARKitPatternTrackingInfo::updateTrackable() {
+    if (transMat) {
+        //visible = true;
+        for (int j = 0; j < 3; j++) {
+            trans[j][0] =  transMat[j][0];
+            trans[j][1] = -transMat[j][1];
+            trans[j][2] = -transMat[j][2];
+            trans[j][3] = (transMat[j][3] * m_scale * 0.001f * 1.64f );
+        }
+    }
+}
+
 void WebARKitPatternTrackingInfo::computeGLviewMatrix() { cv::transpose(pose3d, glViewMatrix); }
 
 void WebARKitPatternTrackingInfo::invertPose() {

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -168,7 +168,7 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
     cv::Mat getPoseMatrix() { return _patternTrackingInfo.pose3d; };
 
-    float* getPoseMatrix2() { return (float*)_patternTrackingInfo.transMat; }
+    float* getPoseMatrix2() { return (float*)_patternTrackingInfo.trans; }
 
     cv::Mat getGLViewMatrix() { return _patternTrackingInfo.glViewMatrix; };
 
@@ -377,6 +377,7 @@ class WebARKitTracker::WebARKitTrackerImpl {
             _patternTrackingInfo.cameraPoseFromPoints(_pose, objPoints, imgPoints, m_camMatrix, m_distortionCoeff);
             // _patternTrackingInfo.computePose(_pattern.points3d, warpedCorners, m_camMatrix, m_distortionCoeff);
             _patternTrackingInfo.getTrackablePose(_pose);
+            _patternTrackingInfo.updateTrackable();
             fill_output(m_H);
             WEBARKIT_LOGi("Marker tracked ! Num. matches : %d\n", numMatches);
         }

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -142,11 +142,13 @@ class WebARKitTracker::WebARKitTrackerImpl {
         assert(grayImage.channels() == 1);
 
         this->_featureDetector->detect(grayImage, keypoints, featureMask);
+        WEBARKIT_LOGd("keypoints size: %d\n", keypoints.size());
         if (keypoints.empty()) {
             WEBARKIT_LOGe("No keypoints detected!\n");
             return false;
         }
         this->_featureDescriptor->compute(grayImage, keypoints, descriptors);
+        WEBARKIT_LOGd("descriptors size: %d\n", descriptors.size());
         if (descriptors.empty()) {
             WEBARKIT_LOGe("No descriptors computed!\n");
             return false;
@@ -155,7 +157,7 @@ class WebARKitTracker::WebARKitTrackerImpl {
     }
 
     void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace,
-                          BLUR_TYPE blurType, bool enableBlur) {
+                          BLUR_TYPE blurType) {
         cv::Mat grayFrame = convert2Grayscale(frameData, frameCols, frameRows, colorSpace);
         if (blurType == BLUR_TYPE::BOX_BLUR) {
             cv::blur(grayFrame, grayFrame, blurSize);
@@ -347,7 +349,7 @@ class WebARKitTracker::WebARKitTrackerImpl {
                 // return false;
             };
             //if (!_isDetected) {
-            WEBARKIT_LOGd("frameKeyPts.size() = %d\n", frameKeyPts.size());
+            WEBARKIT_LOGd("frame KeyPoints size: %d\n", frameKeyPts.size());
             if (static_cast<int>(frameKeyPts.size()) > minRequiredDetectedFeatures) {
                 MatchFeatures(frameKeyPts, frameDescr);
             }
@@ -793,8 +795,8 @@ void WebARKitTracker::initTracker(uchar* refData, size_t refCols, size_t refRows
 }
 
 void WebARKitTracker::processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace,
-                                       BLUR_TYPE blurType,bool enableBlur) {
-    _trackerImpl->processFrameData(frameData, frameCols, frameRows, colorSpace, blurType, enableBlur);
+                                       BLUR_TYPE blurType) {
+    _trackerImpl->processFrameData(frameData, frameCols, frameRows, colorSpace, blurType);
 }
 
 std::vector<double> WebARKitTracker::getOutputData() { return _trackerImpl->getOutputData(); }

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -155,10 +155,13 @@ class WebARKitTracker::WebARKitTrackerImpl {
     }
 
     void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace,
-                          bool enableBlur) {
+                          BLUR_TYPE blurType, bool enableBlur) {
         cv::Mat grayFrame = convert2Grayscale(frameData, frameCols, frameRows, colorSpace);
-        if (enableBlur) {
+        if (blurType == BLUR_TYPE::BOX_BLUR) {
             cv::blur(grayFrame, grayFrame, blurSize);
+        }
+        else if (blurType == BLUR_TYPE::MEDIAN_BLUR) {
+            cv::medianBlur(grayFrame, grayFrame, blurSize.width);
         }
         processFrame(grayFrame);
         grayFrame.release();
@@ -790,8 +793,8 @@ void WebARKitTracker::initTracker(uchar* refData, size_t refCols, size_t refRows
 }
 
 void WebARKitTracker::processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace,
-                                       bool enableBlur) {
-    _trackerImpl->processFrameData(frameData, frameCols, frameRows, colorSpace, enableBlur);
+                                       BLUR_TYPE blurType,bool enableBlur) {
+    _trackerImpl->processFrameData(frameData, frameCols, frameRows, colorSpace, blurType, enableBlur);
 }
 
 std::vector<double> WebARKitTracker::getOutputData() { return _trackerImpl->getOutputData(); }

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitEnums.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitEnums.h
@@ -16,6 +16,12 @@ enum ColorSpace {
     GRAY = 2
 };
 
+enum BLUR_TYPE {
+    MEDIAN_BLUR = 0,
+    BOX_BLUR = 1,
+    NONE_BLUR = 2
+};
+
 } // namespace webarkit
 
 #endif

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
@@ -27,7 +27,7 @@ class WebARKitTracker {
 
     void initTracker(uchar* refData, size_t refCols, size_t refRows, ColorSpace colorSpace);
 
-    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType, bool enableBlur);
+    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType);
 
     std::vector<double> getOutputData();
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
@@ -27,7 +27,7 @@ class WebARKitTracker {
 
     void initTracker(uchar* refData, size_t refCols, size_t refRows, ColorSpace colorSpace);
 
-    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, bool enableBlur);
+    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType, bool enableBlur);
 
     std::vector<double> getOutputData();
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitUtils.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitUtils.h
@@ -125,17 +125,21 @@ static auto convert2Grayscale(uchar* refData, size_t refCols, size_t refRows, Co
         cv::Mat colorFrame(refRows, refCols, CV_8UC4, refData);
         refGray.create(refRows, refCols, CV_8UC1);
         cv::cvtColor(colorFrame, refGray, cv::COLOR_RGBA2GRAY);
+        WEBARKIT_LOGd("convert to GRAY from RGBA !!\n");
     } break;
     case ColorSpace::RGB: {
         cv::Mat colorFrame(refRows, refCols, CV_8UC3, refData);
         refGray.create(refRows, refCols, CV_8UC1);
         cv::cvtColor(colorFrame, refGray, cv::COLOR_RGB2GRAY);
+        WEBARKIT_LOGd("convert to GRAY from RGB !!\n");
     } break;
     case ColorSpace::GRAY: {
         refGray = cv::Mat(refRows, refCols, CV_8UC1, refData);
+        WEBARKIT_LOGd("no need to convert to GRAY!!\n");
     } break;
     default: {
         refGray = cv::Mat(refRows, refCols, CV_8UC1, refData);
+        WEBARKIT_LOGd("Default: no need to convert to GRAY!!\n");
     }
     }
 

--- a/WebARKit/include/WebARKitManager.h
+++ b/WebARKit/include/WebARKitManager.h
@@ -98,7 +98,7 @@ class WebARKitManager {
 
     bool shutdown();
 
-    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, bool enableBlur);
+    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType, bool enableBlur);
 
     std::vector<double> getOutputData();
 

--- a/WebARKit/include/WebARKitManager.h
+++ b/WebARKit/include/WebARKitManager.h
@@ -98,7 +98,7 @@ class WebARKitManager {
 
     bool shutdown();
 
-    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType, bool enableBlur);
+    void processFrameData(uchar* frameData, size_t frameCols, size_t frameRows, ColorSpace colorSpace, BLUR_TYPE blurType);
 
     std::vector<double> getOutputData();
 

--- a/WebARKit/include/WebARKitPattern.h
+++ b/WebARKit/include/WebARKitPattern.h
@@ -26,6 +26,7 @@ class WebARKitPatternTrackingInfo {
     std::vector<cv::Point2f> points2d;
     cv::Mat pose3d;
     float transMat [3][4];
+    float trans [3][4];
     cv::Mat glViewMatrix;
 
     void setScale(const float scale) { m_scale = scale; }
@@ -41,6 +42,8 @@ class WebARKitPatternTrackingInfo {
                      const cv::Mat& distCoeffs);
 
     void getTrackablePose(cv::Mat& pose);
+
+    void updateTrackable();
 
     void computeGLviewMatrix();
 


### PR DESCRIPTION
This pull request includes several changes to the WebARKit codebase, focusing on adding support for different types of blur and improving logging and tracking functionality. The most important changes include the introduction of a `BLUR_TYPE` enum, modifications to the `processFrameData` method to support different blur types, and updates to the tracking information handling.

### Blur type support:
* Introduced `BLUR_TYPE` enum to specify different types of blur: `MEDIAN_BLUR`, `BOX_BLUR`, and `NONE_BLUR`. (`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitEnums.h`)
* Modified `processFrameData` method signatures and implementations to accept `BLUR_TYPE` instead of a boolean for enabling blur. (`WebARKit/WebARKitManager.cpp`, `WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp`, `WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h`, `WebARKit/include/WebARKitManager.h`) [[1]](diffhunk://#diff-1b4d88e26c3de8c4e76c0f063e859a489fe9692cb70a9cfe5c4da1bc60152bbeL82-R82) [[2]](diffhunk://#diff-1b4d88e26c3de8c4e76c0f063e859a489fe9692cb70a9cfe5c4da1bc60152bbeL91-R91) [[3]](diffhunk://#diff-5df4e1007f586521439edc6d7151356a8872b50d115e79fc18c32a0842af94d2L158-R167) [[4]](diffhunk://#diff-5df4e1007f586521439edc6d7151356a8872b50d115e79fc18c32a0842af94d2L792-R799) [[5]](diffhunk://#diff-9c310878927546081afdd844d636d6f3ff1c59a580b139de40b08fca6e9900dbL30-R30) [[6]](diffhunk://#diff-ab036fa887b50dc1104f115e1f9bea62a009b573bacc31aec994ccb357b66c5fL101-R101)

### Logging improvements:
* Added detailed logging for the size of keypoints and descriptors in the `WebARKitTrackerImpl` class. (`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp`) [[1]](diffhunk://#diff-5df4e1007f586521439edc6d7151356a8872b50d115e79fc18c32a0842af94d2R145-R151) [[2]](diffhunk://#diff-5df4e1007f586521439edc6d7151356a8872b50d115e79fc18c32a0842af94d2L347-R352)
* Added logging for color space conversion steps in the `convert2Grayscale` function. (`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitUtils.h`)

### Tracking information updates:
* Added `updateTrackable` method to the `WebARKitPatternTrackingInfo` class to update transformation matrices. (`WebARKit/WebARKitPattern.cpp`, `WebARKit/include/WebARKitPattern.h`) [[1]](diffhunk://#diff-fdd09753c74f94429b059faa1680bca206f5f309d83593a9b392fe68cf4a02bcR56-R67) [[2]](diffhunk://#diff-a3d34aadfe683ee3484d4a1be2e4475827edd92a4c0f5f3570eedbce495f3eb5R46-R47)
* Changed the `getPoseMatrix2` method to return the updated transformation matrix. (`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp`)
* Called the `updateTrackable` method during the tracking process to ensure the transformation matrix is updated. (`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp`)