### PR TITLE
improves to viewMatrix_GL and related code

### DIFF
--- a/WebARKit/WebARKitManager.cpp
+++ b/WebARKit/WebARKitManager.cpp
@@ -111,7 +111,7 @@ cv::Mat WebARKitManager::getGLViewMatrix() {
 
 std::array<double, 16> WebARKitManager::getTransformationMatrix() {
     std::array<double, 16> transformationMatrix;
-    webarkit::arglCameraViewRHf(m_tracker->getPoseMatrix(), transformationMatrix, 1.0f);
+    webarkit::arglCameraViewRHf((float (*)[4])m_tracker->getPoseMatrix2(), (float*)transformationMatrix.data(), 1.0f);
     return transformationMatrix;
 }
 

--- a/WebARKit/WebARKitPattern.cpp
+++ b/WebARKit/WebARKitPattern.cpp
@@ -3,7 +3,7 @@
 
 WebARKitPatternTrackingInfo::WebARKitPatternTrackingInfo() {
     pose3d = cv::Mat::zeros(4, 4, CV_64FC1);
-    glViewMatrix = cv::Mat::zeros(4, 4, CV_64F);
+    glViewMatrix = cv::Mat::zeros(4, 4, CV_64FC1);
     m_scale = 1.0f;
 }
 
@@ -66,6 +66,8 @@ void WebARKitPatternTrackingInfo::updateTrackable() {
 }
 
 void WebARKitPatternTrackingInfo::computeGLviewMatrix() { cv::transpose(pose3d, glViewMatrix); }
+
+void WebARKitPatternTrackingInfo::computeGLviewMatrix(cv::Mat &pose) { cv::transpose(pose, glViewMatrix); }
 
 void WebARKitPatternTrackingInfo::invertPose() {
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -183,6 +183,9 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
     float* getPoseMatrix2() { return (float*)_patternTrackingInfo.trans; }
 
+    //float[3][4] getPoseMatrix3() { return _patternTrackingInfo.trans; }
+    //float (*getPoseMatrix3())[3][4] { return &_patternTrackingInfo.trans; }
+
     cv::Mat getGLViewMatrix() { return _patternTrackingInfo.glViewMatrix; };
 
     std::array<double, 16> getCameraProjectionMatrix() { return m_cameraProjectionMatrix; };
@@ -812,6 +815,9 @@ std::vector<double> WebARKitTracker::getOutputData() { return _trackerImpl->getO
 cv::Mat WebARKitTracker::getPoseMatrix() { return _trackerImpl->getPoseMatrix(); }
 
 float* WebARKitTracker::getPoseMatrix2() { return _trackerImpl->getPoseMatrix2(); }
+
+//float[3][4] WebARKitTracker::getPoseMatrix3() { return _trackerImpl->getPoseMatrix3(); }
+//float (*WebARKitTracker::getPoseMatrix3())[3][4]) { return &_trackerImpl->getPoseMatrix3(); }
 
 cv::Mat WebARKitTracker::getGLViewMatrix() { return _trackerImpl->getGLViewMatrix(); }
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -78,6 +78,14 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
         webarkit::cameraProjectionMatrix(camData, 0.1, 1000.0, frameWidth, frameHeight, m_cameraProjectionMatrix);
 
+        for (auto i = 0; i < 16; i++) {
+
+                WEBARKIT_LOGi("Camera Proj Matrix: %.2f\n", m_cameraProjectionMatrix[i]);
+
+        }
+
+        //1.9102363924347978, 0, 0, 0, 0, 2.5377457054523322, 0, 0, -0.013943280545895442, -0.005830389685211879, -1.0000002000000199, -1, 0, 0, -0.00020000002000000202, 0
+
         _pyramid.clear();
         _prevPyramid.clear();
         _currentlyTrackedMarkers = 0;
@@ -383,6 +391,7 @@ class WebARKitTracker::WebARKitTrackerImpl {
             // _patternTrackingInfo.computePose(_pattern.points3d, warpedCorners, m_camMatrix, m_distortionCoeff);
             _patternTrackingInfo.getTrackablePose(_pose);
             _patternTrackingInfo.updateTrackable();
+            _patternTrackingInfo.computeGLviewMatrix(_pose);
             fill_output(m_H);
             WEBARKIT_LOGi("Marker tracked ! Num. matches : %d\n", numMatches);
         }
@@ -722,7 +731,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
     cv::Mat m_distortionCoeff;
 
     std::array<double, 16> m_cameraProjectionMatrix;
-
   private:
     int _maxNumberOfMarkersToTrack;
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
@@ -35,6 +35,8 @@ class WebARKitTracker {
     
     float* getPoseMatrix2();
 
+    //float (*WebARKitTracker::getPoseMatrix3()[3][4]);
+
     cv::Mat getGLViewMatrix();
 
     std::array<double, 16> getCameraProjectionMatrix();

--- a/WebARKit/include/WebARKitPattern.h
+++ b/WebARKit/include/WebARKitPattern.h
@@ -47,6 +47,8 @@ class WebARKitPatternTrackingInfo {
 
     void computeGLviewMatrix();
 
+    void computeGLviewMatrix(cv::Mat &pose);
+
   private:
     float m_scale;
     void invertPose();


### PR DESCRIPTION
This pull request includes several changes to the `WebARKit` module, focusing on improving the handling of matrix computations and logging. The most important changes include modifying matrix initialization, adding new methods for matrix computation, and enhancing logging for debugging purposes.

Matrix computation improvements:
* [`WebARKit/WebARKitPattern.cpp`](diffhunk://#diff-fdd09753c74f94429b059faa1680bca206f5f309d83593a9b392fe68cf4a02bcL6-R6): Changed the initialization of `glViewMatrix` to use `CV_64FC1` for consistency with `pose3d`.
* `WebARKit/WebARKitPattern.cpp` and `WebARKit/include/WebARKitPattern.h`: Added a new overloaded method `computeGLviewMatrix` that accepts a `cv::Mat` parameter to compute the GL view matrix using a given pose. [[1]](diffhunk://#diff-fdd09753c74f94429b059faa1680bca206f5f309d83593a9b392fe68cf4a02bcR70-R71) [[2]](diffhunk://#diff-a3d34aadfe683ee3484d4a1be2e4475827edd92a4c0f5f3570eedbce495f3eb5R50-R51)

Logging enhancements:
* [`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp`](diffhunk://#diff-5df4e1007f586521439edc6d7151356a8872b50d115e79fc18c32a0842af94d2R81-R88): Added logging for the camera projection matrix to aid in debugging.
* [`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp`](diffhunk://#diff-5df4e1007f586521439edc6d7151356a8872b50d115e79fc18c32a0842af94d2R394): Modified the `updateTrackable` method to call the new `computeGLviewMatrix` method with the current pose, ensuring the GL view matrix is updated accordingly.

Minor changes:
* [`WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp`](diffhunk://#diff-5df4e1007f586521439edc6d7151356a8872b50d115e79fc18c32a0842af94d2L725): Removed an unnecessary line break in the class definition.