### PR TITLE
Fix CV->GL pose conversion in updateTrackable()

### DIFF
--- a/WebARKit/WebARKitPattern.cpp
+++ b/WebARKit/WebARKitPattern.cpp
@@ -55,12 +55,18 @@ void WebARKitPatternTrackingInfo::getTrackablePose(cv::Mat& pose) {
 
 void WebARKitPatternTrackingInfo::updateTrackable() {
     if (transMat) {
-        //visible = true;
+        // Keep `trans` as the raw OpenCV pose (rotation unmodified, translation
+        // scaled). The CV->GL handedness conversion (negate Y and Z rows incl.
+        // translation) is applied downstream by arglCameraViewRHf when building
+        // the GL right-handed modelview (matrixGL_RH / getGLViewMatrix).
+        // Previously, rotation columns 1 and 2 were negated here but the
+        // translation was not, producing an inconsistent partial conversion
+        // that left tracked objects behind the camera in OpenGL renderers.
         for (int j = 0; j < 3; j++) {
-            trans[j][0] =  transMat[j][0];
-            trans[j][1] = -transMat[j][1];
-            trans[j][2] = -transMat[j][2];
-            trans[j][3] = (transMat[j][3] * m_scale * 0.001f * 1.64f );
+            trans[j][0] = transMat[j][0];
+            trans[j][1] = transMat[j][1];
+            trans[j][2] = transMat[j][2];
+            trans[j][3] = (transMat[j][3] * m_scale * 0.001f * 1.64f);
         }
     }
 }


### PR DESCRIPTION
## Summary

Stop applying a partial CV→GL conversion in `WebARKitPatternTrackingInfo::updateTrackable()`. Today the rotation columns Y and Z are negated but the translation isn't — an inconsistent half-conversion that leaves consumers with a pose where translation Z stays positive. Under a standard OpenGL projection (which expects objects in front to have negative Z in view space), tracked objects clip behind the camera and never render.

After this change, `getPoseMatrix2()` / `trans` carry the **raw OpenCV pose** (rotation unmodified, translation kept at the existing `0.001 * 1.64` scale). The CV→GL handedness flip (negate Y and Z rows *including* translation) is then applied uniformly downstream by `arglCameraViewRHf`, producing a mathematically clean `diag(1, -1, -1, 1) * pose` modelview that places the tracked object in front of the GL camera.

Both downstream paths benefit:
- JS side: `WebARKitController.process_raw` → `arglCameraViewRHf(pose, ...)` → correct `matrixGL_RH`.
- C++ side: `WebARKitManager::getGLViewMatrix()` → `arglCameraViewRHf(getPoseMatrix2(), ...)` → correct modelview.

Surfaced and verified downstream by webarkit/webarkit-testing#31 / #32 (static-image Teblid example): with this fix the AR overlay is no longer frustum-clipped behind the camera.

## Breaking change note

This **changes the runtime semantics of `pose` / `trans`** for any consumer that relied on the previous partially-converted shape. Consumers rendering with OpenGL/three.js should now use **`matrixGL_RH`** (or `getGLViewMatrix()` in C++) as the GL-ready modelview, and treat `pose` as the raw OpenCV camera pose (`[R | t]`, +Z forward).

## Diff

A single 4-line hunk in `WebARKit/WebARKitPattern.cpp` (drop two `-` signs, plus a comment explaining the convention).

## Test plan

- [ ] Existing gtests still pass (no projection-matrix value asserted against this code path).
- [ ] Downstream: rebuild WASM, load `examples/threejs_teblid_static_image_ES6_example.html` from webarkit/webarkit-testing#32 (after the companion PR), confirm sphere appears anchored to the marker rather than clipped behind the camera.

## Related

- Resolves the rendering side of webarkit/WebARKitLib#34 (pose convention).
- A separate projection X-mirror remains, tracked in webarkit/WebARKitLib#35.
- Downstream PR consuming this: webarkit/webarkit-testing (will be posted as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)