### PR TITLE
Fix crash when a marker is detected on the first frame (#37)

### DIFF
--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/TrackingPointSelector.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/TrackingPointSelector.cpp
@@ -170,6 +170,13 @@ std::vector<cv::Point2f> TrackingPointSelector::GetTrackedFeaturesWarped()
 {
     std::vector<cv::Point2f> selectedPoints = GetTrackedFeatures();
     std::vector<cv::Point2f> warpedPoints;
+    // cv::perspectiveTransform asserts on an empty input (and requires a valid
+    // 3x3 homography). This happens when a marker is detected on the very first
+    // frame, before the tracked-point selection has been populated. Return an
+    // empty result instead of throwing.
+    if (selectedPoints.empty() || _homography.empty()) {
+        return warpedPoints;
+    }
     perspectiveTransform(selectedPoints, warpedPoints, _homography);
     return warpedPoints;
 }

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -390,13 +390,20 @@ class WebARKitTracker::WebARKitTrackerImpl {
             cv::Mat _pose;
             std::vector<cv::Point2f> imgPoints = _trackSelection.GetTrackedFeaturesWarped();
             std::vector<cv::Point3f> objPoints = _trackSelection.GetTrackedFeatures3d();
-            _patternTrackingInfo.cameraPoseFromPoints(_pose, objPoints, imgPoints, m_camMatrix, m_distortionCoeff);
-            // _patternTrackingInfo.computePose(_pattern.points3d, warpedCorners, m_camMatrix, m_distortionCoeff);
-            _patternTrackingInfo.getTrackablePose(_pose);
-            _patternTrackingInfo.updateTrackable();
-            _patternTrackingInfo.computeGLviewMatrix(_pose);
-            fill_output(m_H);
-            WEBARKIT_LOGi("Marker tracked ! Num. matches : %d\n", numMatches);
+            // Need at least 4 correspondences for solvePnP, and the two sets must
+            // match in size. On the very first frame a marker can be detected
+            // before the tracked-point selection is populated (the optical-flow
+            // branch that calls GetInitialFeatures() is gated on _frameCount > 0),
+            // leaving these empty. Skip pose estimation in that case.
+            if (imgPoints.size() >= 4 && imgPoints.size() == objPoints.size()) {
+                _patternTrackingInfo.cameraPoseFromPoints(_pose, objPoints, imgPoints, m_camMatrix, m_distortionCoeff);
+                // _patternTrackingInfo.computePose(_pattern.points3d, warpedCorners, m_camMatrix, m_distortionCoeff);
+                _patternTrackingInfo.getTrackablePose(_pose);
+                _patternTrackingInfo.updateTrackable();
+                _patternTrackingInfo.computeGLviewMatrix(_pose);
+                fill_output(m_H);
+                WEBARKIT_LOGi("Marker tracked ! Num. matches : %d\n", numMatches);
+            }
         }
 
         swapImagePyramid();


### PR DESCRIPTION
## Summary

Fixes #37. `processFrame()` could call `GetTrackedFeaturesWarped()` with an **empty tracked-point selection** on the very first frame, making `cv::perspectiveTransform` assert and throw.

Root cause: the optical-flow branch that calls `GetInitialFeatures()` (which populates `_selectedPts`) is gated on `_frameCount > 0`, but `MatchFeatures()` can set `_isDetected = true` on frame 0. The pose block (`if (_isDetected || _isTracking)`) then calls `GetTrackedFeaturesWarped()` on the empty selection → `perspectiveTransform` hits `CV_Assert(scn + 1 == m.cols)` (empty input → 1-channel Mat → `2 == 3`).

A live camera masks this (detection essentially never succeeds on the literal first frame); a **static image** triggers it deterministically.

## Changes

- **`TrackingPointSelector::GetTrackedFeaturesWarped()`** — return an empty result when the selection or the homography is empty, instead of calling `perspectiveTransform` on empty input (fixes the crash at the source).
- **`WebARKitTracker::processFrame()`** — only run pose estimation when there are `>= 4` correspondences and the image/object point counts match (`solvePnP` needs ≥4; avoids estimating from an empty/degenerate set).

Both are defensive and do not change behavior on frames where the selection is properly populated.

## Verification

Built to WASM and run in the webarkit-testing static Teblid example **with its warmup frame removed**, so the real image is processed on frame 0 and exercises the exact crash path:

- Before: `cv::error` / `perspectiveTransform` exception (stack: `GetTrackedFeaturesWarped` → `processFrame`).
- After: **no exception**; the tracker reports not-found on frame 0 and proceeds normally.

Existing examples (with their normal frame flow) are unaffected.

## Notes

The webarkit-testing static example currently feeds a blank warmup frame as a workaround; with this fix the library is robust against frame-0 detection for any consumer, so the warmup is no longer required for crash-avoidance (it's retained there only to smooth the static-image detection→tracking handoff).

Refs: webarkit/webarkit-testing#30, #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)