### PR TITLE
fix(kpm/matcher): use std::map for deterministic iteration in vote tally, keyframes, and BHC clusters

### DIFF
--- a/lib/SRC/KPM/FreakMatcher/matchers/binary_hierarchical_clustering.h
+++ b/lib/SRC/KPM/FreakMatcher/matchers/binary_hierarchical_clustering.h
@@ -37,7 +37,7 @@
 
 #include "kmedoids.h"
 
-#include <unordered_map>
+#include <map>
 #include <queue>
 
 namespace vision {
@@ -214,7 +214,16 @@ namespace vision {
         typedef Node<NUM_BYTES_PER_FEATURE> node_t;
         typedef std::unique_ptr<node_t> node_ptr_t;
         typedef BinarykMedoids<NUM_BYTES_PER_FEATURE> kmedoids_t;
-        typedef std::unordered_map<int, std::vector<int> > cluster_map_t;
+        // std::map (not std::unordered_map): BHC tree construction
+        // iterates this map to build the topology of clusters. With
+        // unordered_map, the resulting tree's child ordering varied
+        // across STL implementations and produced different BHC
+        // topologies on different platforms, which propagated into
+        // different inlier sets and homographies. std::map's
+        // ascending-key iteration makes BHC tree topology
+        // deterministic. Mirrors the BTreeMap fix on the Rust port
+        // (see freak/clustering.rs and issue #170).
+        typedef std::map<int, std::vector<int> > cluster_map_t;
         
         typedef PriorityQueueItem<NUM_BYTES_PER_FEATURE> queue_item_t;
         typedef std::priority_queue<queue_item_t> queue_t;

--- a/lib/SRC/KPM/FreakMatcher/matchers/hough_similarity_voting.h
+++ b/lib/SRC/KPM/FreakMatcher/matchers/hough_similarity_voting.h
@@ -40,18 +40,26 @@
 #include <framework/error.h>
 
 #include <vector>
-#include <unordered_map>
+#include <map>
 
 namespace vision {
 
     /**
-     * Hough voting for a similarity transformation based on a set of correspondences. 
+     * Hough voting for a similarity transformation based on a set of correspondences.
      */
     class HoughSimilarityVoting
     {
     public:
-        
-        typedef std::unordered_map<unsigned int, unsigned int> hash_t;
+
+        // std::map (not std::unordered_map): the vote-tally is consumed
+        // by getMaximumNumberOfVotes, which iterates and picks the bin
+        // with the highest count. unordered_map has implementation-
+        // defined iteration order (libstdc++ vs MSVC STL) so tied bins
+        // produced different winners across platforms, making the
+        // matcher non-deterministic across builds. std::map gives a
+        // stable ascending-key ordering that resolves ties consistently.
+        // Mirrors the BTreeMap fix on the Rust port (issue #170).
+        typedef std::map<unsigned int, unsigned int> hash_t;
         typedef std::pair<int /*size*/, int /*index*/> vote_t;
         typedef std::vector<vote_t> vote_vector_t;
         

--- a/lib/SRC/KPM/FreakMatcher/matchers/visual_database.h
+++ b/lib/SRC/KPM/FreakMatcher/matchers/visual_database.h
@@ -48,7 +48,7 @@
 
 #include <vector>
 #include <memory>
-#include <unordered_map>
+#include <map>
 
 #include "feature_point.h"
 
@@ -69,7 +69,15 @@ namespace vision {
         
         typedef Keyframe<96> keyframe_t;
         typedef std::shared_ptr<keyframe_t> keyframe_ptr_t;
-        typedef std::unordered_map<id_t, keyframe_ptr_t> keyframe_map_t;
+        // std::map (not std::unordered_map): query() iterates this
+        // collection and breaks ties on inlier-count with a strict
+        // "first wins" comparison. unordered_map has implementation-
+        // defined iteration order, so the winning keyframe on
+        // borderline ties varied across libstdc++ vs MSVC STL builds.
+        // std::map's ascending-key order makes the tie-breaking
+        // platform-independent. Mirrors the BTreeMap fix on the Rust
+        // port (issue #170).
+        typedef std::map<id_t, keyframe_ptr_t> keyframe_map_t;
         
         typedef BinomialPyramid32f pyramid_t;
         typedef DoGScaleInvariantDetector detector_t;


### PR DESCRIPTION
## Summary

Three `std::unordered_map` typedefs in the KPM FreakMatcher have iteration-order-sensitive consumers and were producing **different matcher output on different platforms** (libstdc++ on Linux vs MSVC STL on Windows vs libc++ on macOS / Emscripten). The C++ standard makes `unordered_map`'s iteration order implementation-defined, and the matcher's tie-breaking code paths read that order directly. Result: same input, same code, different matched keyframe on different OSes.

Mechanically replace the three with `std::map<...>`. `std::map`'s ascending-key iteration is consistent across STL implementations.

## The three culprits

| File | Typedef | Iteration-sensitive consumer |
|---|---|---|
| `matchers/hough_similarity_voting.h:54` | `hash_t` (vote tally) | `getMaximumNumberOfVotes` iterates and picks the bin with the highest count; tied bins were broken inconsistently per platform. |
| `matchers/visual_database.h:72` | `keyframe_map_t` | `query()` iterates and breaks ties on inlier count first-wins; winning keyframe at borderline ties depended on platform iteration order. |
| `matchers/binary_hierarchical_clustering.h:217` | `cluster_map_t` | BHC tree construction iterates clusters; ordering changes tree topology, which propagates into different inlier sets. |

`VisualDatabaseImpl::point3d_map_t` in `facade/visual_database_facade.cpp:46` is **intentionally left** as `std::unordered_map` — it's used lookup-only (`map[image_id] = ...`, `return map[image_id]`) so iteration order is irrelevant. Changing it would be cosmetic only.

## Concrete repro of the bug

The pure-Rust port at [webarkit/WebARKitLib-rs](https://github.com/webarkit/WebARKitLib-rs) has a dual-mode test harness that runs both the C++ matcher (via FFI) and a pure-Rust matcher on the same input frame. When the harness was wired into CI on multiple OSes (issue [webarkit/WebARKitLib-rs#170](https://github.com/webarkit/WebARKitLib-rs/issues/170)):

| Platform | C++ matched_id on `pinball-demo.jpg` |
|---|---|
| Windows (MSVC STL) | **2** (db_id=2, 595×745 pyramid level) |
| Ubuntu CI (libstdc++) | **1** (db_id=1, 750×938 pyramid level) |

Same `.fset3`, same query, same compiler flags — different match. This commit, paired with the equivalent BTreeMap fix on the Rust side ([webarkit/WebARKitLib-rs#171](https://github.com/webarkit/WebARKitLib-rs/pull/171)), should make both backends produce platform-deterministic output.

## API surface change

**None.** `std::map` and `std::unordered_map` share all the operations used here: `operator[]`, `find`, `insert`, `erase`, `clear`, iterators. Drop-in.

## Performance impact

- `O(log N)` lookup instead of `O(1)` amortized.
- N is small for all three maps:
  - keyframes per VisualDatabase: typically 1-10
  - Hough bins voted-for in a single query: typically 10s
  - BHC clusters per level: 1-100
- For these N values, the constant factor on a tree node traversal is comparable to a hash computation, so the practical perf difference is negligible.

## Test plan

- Built clean from `WebARKitLib-rs` consumers using this commit's SHA — see the corresponding submodule-bump PR [webarkit/WebARKitLib-rs#NNN] (to be opened once this PR lands).
- All `WebARKitLib-rs` dual-mode tests pass against the change locally on Windows.
- CI on `WebARKitLib-rs` will validate the cross-platform behavior on Ubuntu once the submodule is bumped.

## References

- [webarkit/WebARKitLib-rs#170](https://github.com/webarkit/WebARKitLib-rs/issues/170) — the issue with the cross-platform repro and motivation.
- [webarkit/WebARKitLib-rs#171](https://github.com/webarkit/WebARKitLib-rs/pull/171) — the equivalent fix on the Rust port (`HashMap` → `BTreeMap`).
- [webarkit/WebARKitLib-rs#169](https://github.com/webarkit/WebARKitLib-rs/pull/169) — the corner-error regression gate that first surfaced the cross-platform divergence in CI.