### PR TITLE
Declare tracking lost when the marker leaves the frame (#46)

### DIFF
--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -297,6 +297,14 @@ class WebARKitTracker::WebARKitTrackerImpl {
             // _trackables[trackableId]._isDetected = false;
             _isTracking = false;
             _isDetected = false;
+            // WebARKitLib#46: template matching is the appearance check -- if it fails
+            // (the tracked region no longer looks like the marker, e.g. the marker
+            // left the frame and optical flow drifted onto static background), the
+            // marker is lost. Clear _valid too so isValid() turns false and the
+            // tracker reports 'not found'. runOpticalFlow's failure path already does
+            // this; ArtoolkitX has no _valid and treats !isDetected && !isTracking as
+            // "not visible" (IsTrackableVisible).
+            this->_valid = false;
             _currentlyTrackedMarkers--;
         }
         if (_trackVizActive) {
@@ -344,7 +352,15 @@ class WebARKitTracker::WebARKitTrackerImpl {
             MatchFeatures(frameKeyPts, frameDescr);
         }
         int i = 0;
-        if (_isDetected) {
+        // WebARKitLib#46: also run optical flow while tracking, not only on a fresh
+        // detection. When the marker leaves the frame, MatchFeatures fails
+        // (_isDetected = false) but _isTracking is still true; running optical flow
+        // here lets it fail on the now-absent marker and clear _isTracking/_valid
+        // (via updateTrackableHomography), so isValid() turns false and the tracker
+        // reports 'not found' instead of staying stuck on a stale pose. It also
+        // bridges momentary detection dropouts with a fresh pose while the marker is
+        // still present.
+        if (_isDetected || _isTracking) {
             WEBARKIT_LOGd("Start tracking!\n");
             if (_frameCount > 0 && _prevPyramid.size() > 0) {
                 // if (_prevPyramid.size() > 0) {


### PR DESCRIPTION
## Summary

Fixes #46: after a marker is acquired, `isValid()` / the `getMarker` event kept emitting **found** with a frozen pose indefinitely once the marker left the frame. Two coupled changes in `WebARKitTracker.cpp` make the tracker declare loss, matching the ArtoolkitX OCVT semantics.

## Root cause

WebARKit diverged from ArtoolkitX's tracker state machine in two ways:

1. **Track loop gated on `_isDetected` only.** WebARKit resets `_isDetected = false` every frame and runs detection every frame, so `_isDetected` means "matched *this* frame." Once the marker leaves, `MatchFeatures` fails → `_isDetected = false` → the optical-flow + template-match path was skipped entirely, so loss was never evaluated. (ArtoolkitX runs that path on a *persistent* `_isDetected` with guarded detection, so it re-validates every frame.)
2. **`_valid` not reset on template-match failure.** Template matching is the appearance check. When the marker is replaced by a static background, optical flow keeps the points (they don't move → no failure), but the marker template no longer matches → `updateTrackableHomography` fails. `runOpticalFlow`'s failure path already cleared `_valid`; `RunTemplateMatching`'s did not — so `isValid()` stayed true and `getMarker` kept firing.

ArtoolkitX has no `_valid`: `IsTrackableVisible`/`GetTrackablePose` are gated purely on `_isDetected || _isTracking`, and `RunTemplateMatching` failure sets both false.

## Changes

- `resetTracking()`: run the optical-flow/template-match block on **`_isDetected || _isTracking`** (was `_isDetected`), so a tracked-but-not-detected frame still re-validates (and fails → clears state) when the marker is gone.
- `RunTemplateMatching()` failure path: also set **`_valid = false`** (mirrors `runOpticalFlow`'s failure path), so a lost marker propagates to `isValid()`.

## Behavior

- Marker present: unchanged — `found`, stable pose (template matching passes on the real marker; detection re-acquires every frame).
- Marker leaves: within ~1–2 frames, template matching fails → `_isDetected/_isTracking/_valid` cleared → `isValid()` false → `not found`. Content can be hidden by consumers.

## Testing

Verified against the live-webcam Teblid example (webarkit/webarkit-testing#37): acquiring the marker shows the AR content; removing it now flips to "Searching…" and hides the content within a frame or two; re-introducing re-acquires; **no flicker** while the marker is held in view.

## Notes / follow-ups
- Independent of the disabled detection guard / downsampling (perf) — that's #44.
- If marginal frames ever cause false-loss flicker on a present marker, add hysteresis / tune the `TM_SQDIFF_NORMED < 0.5` template threshold (a robustness layer, not needed in testing).

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)