### PR TITLE
fix(#55): populate pose3d (getPoseMatrix returned zeros) + rename pose getters

### DIFF
--- a/WebARKit/WebARKitManager.cpp
+++ b/WebARKit/WebARKitManager.cpp
@@ -97,12 +97,12 @@ std::vector<double> WebARKitManager::getOutputData() {
     return m_tracker->getOutputData();
 };
 
-cv::Mat WebARKitManager::getPoseMatrix() {
-    return m_tracker->getPoseMatrix();
+cv::Mat WebARKitManager::getPoseMatrixCV() {
+    return m_tracker->getPoseMatrixCV();
 }
 
-float* WebARKitManager::getPoseMatrix2() {
-    return m_tracker->getPoseMatrix2();
+float* WebARKitManager::getPoseMatrixGL() {
+    return m_tracker->getPoseMatrixGL();
 }
 
 cv::Mat WebARKitManager::getGLViewMatrix() {
@@ -111,7 +111,7 @@ cv::Mat WebARKitManager::getGLViewMatrix() {
 
 std::array<double, 16> WebARKitManager::getTransformationMatrix() {
     std::array<double, 16> transformationMatrix;
-    webarkit::arglCameraViewRHf((float (*)[4])m_tracker->getPoseMatrix2(), (float*)transformationMatrix.data(), 1.0f);
+    webarkit::arglCameraViewRHf((float (*)[4])m_tracker->getPoseMatrixGL(), (float*)transformationMatrix.data(), 1.0f);
     return transformationMatrix;
 }
 

--- a/WebARKit/WebARKitPattern.cpp
+++ b/WebARKit/WebARKitPattern.cpp
@@ -19,6 +19,21 @@ void WebARKitPatternTrackingInfo::cameraPoseFromPoints(cv::Mat& pose, const std:
     cv::Mat rMat;
     Rodrigues(rvec, rMat);
     cv::hconcat(rMat, tvec, pose);
+
+    // WebARKitLib#55: also populate pose3d -- the raw 4x4 OpenCV-convention camera
+    // pose returned by getPoseMatrixCV(). The live path previously left pose3d at its
+    // zero-initialised value (only the now-dead computePose wrote it), so
+    // getPoseMatrixCV() returned an all-zero matrix. Build it here from the same
+    // rMat/tvec the GL path uses, so the CV and GL getters both reflect the current
+    // frame. No handedness/scale correction is applied (that is getPoseMatrixGL's
+    // trans); pose3d stays in raw OpenCV convention.
+    for (int row = 0; row < 3; ++row) {
+        for (int col = 0; col < 3; ++col) {
+            pose3d.at<double>(row, col) = rMat.at<double>(row, col);
+        }
+        pose3d.at<double>(row, 3) = tvec.at<double>(row, 0);
+    }
+    pose3d.at<double>(3, 3) = 1.0;
 };
 
 void WebARKitPatternTrackingInfo::computePose(std::vector<cv::Point3f>& treeDPoints,

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -190,9 +190,9 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
     std::vector<double> getOutputData() { return output; };
 
-    cv::Mat getPoseMatrix() { return _patternTrackingInfo.pose3d; };
+    cv::Mat getPoseMatrixCV() { return _patternTrackingInfo.pose3d; };
 
-    float* getPoseMatrix2() { return (float*)_patternTrackingInfo.trans; }
+    float* getPoseMatrixGL() { return (float*)_patternTrackingInfo.trans; }
 
     //float[3][4] getPoseMatrix3() { return _patternTrackingInfo.trans; }
     //float (*getPoseMatrix3())[3][4] { return &_patternTrackingInfo.trans; }
@@ -892,9 +892,9 @@ void WebARKitTracker::processFrameData(uchar* frameData, size_t frameCols, size_
 
 std::vector<double> WebARKitTracker::getOutputData() { return _trackerImpl->getOutputData(); }
 
-cv::Mat WebARKitTracker::getPoseMatrix() { return _trackerImpl->getPoseMatrix(); }
+cv::Mat WebARKitTracker::getPoseMatrixCV() { return _trackerImpl->getPoseMatrixCV(); }
 
-float* WebARKitTracker::getPoseMatrix2() { return _trackerImpl->getPoseMatrix2(); }
+float* WebARKitTracker::getPoseMatrixGL() { return _trackerImpl->getPoseMatrixGL(); }
 
 //float[3][4] WebARKitTracker::getPoseMatrix3() { return _trackerImpl->getPoseMatrix3(); }
 //float (*WebARKitTracker::getPoseMatrix3())[3][4]) { return &_trackerImpl->getPoseMatrix3(); }

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
@@ -31,9 +31,9 @@ class WebARKitTracker {
 
     std::vector<double> getOutputData();
 
-    cv::Mat getPoseMatrix();
+    cv::Mat getPoseMatrixCV();
     
-    float* getPoseMatrix2();
+    float* getPoseMatrixGL();
 
     //float (*WebARKitTracker::getPoseMatrix3()[3][4]);
 

--- a/WebARKit/include/WebARKitManager.h
+++ b/WebARKit/include/WebARKitManager.h
@@ -102,9 +102,9 @@ class WebARKitManager {
 
     std::vector<double> getOutputData();
 
-    cv::Mat getPoseMatrix();
+    cv::Mat getPoseMatrixCV();
 
-    float* getPoseMatrix2();
+    float* getPoseMatrixGL();
 
     cv::Mat getGLViewMatrix();
 


### PR DESCRIPTION
Fixes #55.

## The bug

`getPoseMatrix()` (the cv::Mat / 4×4 pose, bound to JS) returned an **all-zero matrix**. It reads `_patternTrackingInfo.pose3d`, but the live tracking path never wrote `pose3d` — the pose flows `_pose` → `transMat` → `trans` (what `getPoseMatrix2` returns), while `pose3d` was touched only by the dead `computePose`/`invertPose`. Unnoticed because the examples read `getPoseMatrix2`, not `getPoseMatrix`.

## The fix

`cameraPoseFromPoints` now also builds `pose3d` (the raw 4×4 OpenCV-convention pose) from the same `rMat`/`tvec` it already computes, so the CV getter reflects the current frame. No handedness/scale correction is applied to `pose3d` (that remains `getPoseMatrixGL`'s `trans`).

## The rename (rides along, agreed in #55)

The `2` suffix hid that the two getters differ in **both** convention and shape:

| before | returns | after |
|---|---|---|
| `getPoseMatrix` | raw OpenCV 4×4 pose | **`getPoseMatrixCV`** |
| `getPoseMatrix2` | right-handed/GL pose (`trans`) | **`getPoseMatrixGL`** |

Hard rename across `WebARKitManager` + `WebARKitTracker` (decls, inner impl, outer wrapper). The matching emscripten bindings + `WebARKitController` wrapper are in the companion webarkit-testing PR.

## Testing

Rebuilt (Docker emscripten) and tested both examples:
- **static** (1920×1440, pyrLevel 1) and **webcam** (640×480, pyrLevel 0) both track — 1000 matches, lost→found re-acquisition intact.
- `getPoseMatrixCV()` now returns a valid `[R|t;0001]` (e.g. rotation block + translation + `[0,0,0,1]`); was all zeros before.

## Follow-up

The now-redundant `computePose` / `invertPose` / `computeGLviewMatrix()` (no-arg) become removable — tracked in the #50 cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)