### PR TITLE
refactor(#50): remove dead stub + commented-out scaffolding

### DIFF
--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -194,8 +194,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
     float* getPoseMatrixGL() { return (float*)_patternTrackingInfo.trans; }
 
-    //float[3][4] getPoseMatrix3() { return _patternTrackingInfo.trans; }
-    //float (*getPoseMatrix3())[3][4] { return &_patternTrackingInfo.trans; }
 
     cv::Mat getGLViewMatrix() { return _patternTrackingInfo.glViewMatrix; };
 
@@ -212,9 +210,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
         // std::cout << "Starting template match" << std::endl;
         std::vector<cv::Point2f> finalTemplatePoints, finalTemplateMatchPoints;
         // Get a handle on the corresponding points from current image and the marker
-        // std::vector<cv::Point2f> trackablePoints = _trackables[trackableId]._trackSelection.GetTrackedFeatures();
-        // std::vector<cv::Point2f> trackablePointsWarped =
-        // _trackables[trackableId]._trackSelection.GetTrackedFeaturesWarped();
         std::vector<cv::Point2f> trackablePoints = _trackSelection.GetTrackedFeatures();
         std::vector<cv::Point2f> trackablePointsWarped = _trackSelection.GetTrackedFeaturesWarped();
         // Create an empty result image - May be able to pre-initialize this container
@@ -227,22 +222,16 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
         for (int j = 0; j < n; j++) {
             auto pt = trackablePointsWarped[j];
-            // if (cv::pointPolygonTest(_trackables[trackableId]._bBoxTransformed, trackablePointsWarped[j], true) > 0)
-            // {
             if (cv::pointPolygonTest(_bBoxTransformed, trackablePointsWarped[j], true) > 0) {
                 auto ptOrig = trackablePoints[j];
 
                 cv::Rect templateRoi = GetTemplateRoi(pt);
                 cv::Rect frameROI(0, 0, frame.cols, frame.rows);
                 if (IsRoiValidForFrame(frameROI, templateRoi)) {
-                    // cv::Rect markerRoi(0, 0, _trackables[trackableId]._image.cols,
-                    // _trackables[trackableId]._image.rows);
                     cv::Rect markerRoi(0, 0, _image.cols, _image.rows);
 
                     std::vector<cv::Point2f> vertexPoints = GetVerticesFromPoint(ptOrig);
                     std::vector<cv::Point2f> vertexPointsResults;
-                    // perspectiveTransform(vertexPoints, vertexPointsResults,
-                    // _trackables[trackableId]._trackSelection.GetHomography());
                     perspectiveTransform(vertexPoints, vertexPointsResults, _trackSelection.GetHomography());
 
                     cv::Rect srcBoundingBox = cv::boundingRect(cv::Mat(vertexPointsResults));
@@ -250,8 +239,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
                     vertexPoints.clear();
                     vertexPoints = GetVerticesFromTopCorner(srcBoundingBox.x, srcBoundingBox.y, srcBoundingBox.width,
                                                             srcBoundingBox.height);
-                    // perspectiveTransform(vertexPoints, vertexPointsResults,
-                    // _trackables[trackableId]._trackSelection.GetHomography().inv());
                     perspectiveTransform(vertexPoints, vertexPointsResults, _trackSelection.GetHomography().inv());
 
                     std::vector<cv::Point2f> testVertexPoints = FloorVertexPoints(vertexPointsResults);
@@ -269,7 +256,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
 
                             if (templateBoundingBox.area() > 0 && searchROI.area() > templateBoundingBox.area()) {
                                 cv::Mat searchImage = frame(searchROI);
-                                // cv::Mat templateImage = _trackables[trackableId]._image(templateBoundingBox);
                                 cv::Mat templateImage = _image(templateBoundingBox);
                                 cv::Mat warpedTemplate;
 
@@ -319,8 +305,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
         }
         bool gotHomography = updateTrackableHomography(trackableId, finalTemplatePoints, finalTemplateMatchPoints);
         if (!gotHomography) {
-            // _trackables[trackableId]._isTracking = false;
-            // _trackables[trackableId]._isDetected = false;
             _isTracking = false;
             _isDetected = false;
             // WebARKitLib#46: template matching is the appearance check -- if it fails
@@ -501,7 +485,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
         int maxMatches = 0;
         int bestMatchIndex = -1;
         std::vector<cv::KeyPoint> finalMatched1, finalMatched2;
-        // for (int i = 0; i < _trackables.size(); i++) {
         if (!_isDetected) {
             std::vector<std::vector<cv::DMatch>> matches = getMatches(newFrameDescriptors);
             numMatches = matches.size();
@@ -549,24 +532,17 @@ class WebARKitTracker::WebARKitTrackerImpl {
                 getHomographyInliers(Points(finalMatched2), Points(finalMatched1));
             if (homoInfo.validHomography) {
                 // std::cout << "New marker detected" << std::endl;
-                //_trackables[bestMatchIndex]._isDetected = true;
                 _isDetected = true;
                 // Since we've just detected the marker, make sure next invocation of
                 // GetInitialFeatures() for this marker makes a new selection.
-                //_trackables[bestMatchIndex]._trackSelection.ResetSelection();
                 _trackSelection.ResetSelection();
-                //_trackables[bestMatchIndex]._trackSelection.SetHomography(homoInfo.homography);
                 _trackSelection.SetHomography(homoInfo.homography);
 
                 // Use the homography to form the initial estimate of the bounding box.
                 // This will be refined by the optical flow pass.
-                // perspectiveTransform(_trackables[bestMatchIndex]._bBox, _trackables[bestMatchIndex]._bBoxTransformed,
-                // homoInfo.homography);
                 perspectiveTransform(_bBox, _bBoxTransformed, homoInfo.homography);
                 if (_trackVizActive) {
                     for (int i = 0; i < 4; i++) {
-                        // _trackViz.bounds[i][0] = _trackables[bestMatchIndex]._bBoxTransformed[i].x;
-                        // _trackViz.bounds[i][1] = _trackables[bestMatchIndex]._bBoxTransformed[i].y;
                         _trackViz.bounds[i][0] = _bBoxTransformed[i].x;
                         _trackViz.bounds[i][1] = _bBoxTransformed[i].y;
                     }
@@ -632,14 +608,11 @@ class WebARKitTracker::WebARKitTrackerImpl {
                 perspectiveTransform(_bBox, _bBoxTransformed, homoInfo.homography);
                 if (_trackVizActive) {
                     for (int i = 0; i < 4; i++) {
-                        // _trackViz.bounds[i][0] = _trackables[trackableId]._bBoxTransformed[i].x;
-                        // _trackViz.bounds[i][1] = _trackables[trackableId]._bBoxTransformed[i].y;
                         _trackViz.bounds[i][0] = _bBoxTransformed[i].x;
                         _trackViz.bounds[i][1] = _bBoxTransformed[i].y;
                     }
                 }
                 if (_frameCount > 1) {
-                    // _trackables[trackableId]._trackSelection.ResetSelection();
                     _trackSelection.ResetSelection();
                 }
                 return true;
@@ -896,8 +869,6 @@ cv::Mat WebARKitTracker::getPoseMatrixCV() { return _trackerImpl->getPoseMatrixC
 
 float* WebARKitTracker::getPoseMatrixGL() { return _trackerImpl->getPoseMatrixGL(); }
 
-//float[3][4] WebARKitTracker::getPoseMatrix3() { return _trackerImpl->getPoseMatrix3(); }
-//float (*WebARKitTracker::getPoseMatrix3())[3][4]) { return &_trackerImpl->getPoseMatrix3(); }
 
 cv::Mat WebARKitTracker::getGLViewMatrix() { return _trackerImpl->getGLViewMatrix(); }
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.h
@@ -35,7 +35,6 @@ class WebARKitTracker {
     
     float* getPoseMatrixGL();
 
-    //float (*WebARKitTracker::getPoseMatrix3()[3][4]);
 
     cv::Mat getGLViewMatrix();
 

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitUtils.h
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/include/WebARKitTrackers/WebARKitOpticalTracking/WebARKitUtils.h
@@ -73,27 +73,6 @@ static homography::WebARKitHomographyInfo getHomographyInliers(std::vector<cv::P
     return homography::WebARKitHomographyInfo(homography, status, inlier_matches);
 }
 
-/*static auto im_gray(uchar* data, size_t cols, size_t rows) {
-    uint32_t idx;
-    uchar gray[rows][cols];
-    for (int i = 0; i < rows; ++i) {
-        for (int j = 0; j < cols; ++j) {
-            idx = (i * cols * 4) + j * 4;
-
-            // rgba to rgb
-            uchar r = data[idx];
-            uchar g = data[idx + 1];
-            uchar b = data[idx + 2];
-            // uchar a = data[idx + 3];
-
-            // turn frame image to gray scale
-            gray[i][j] = (0.30 * r) + (0.59 * g) + (0.11 * b);
-        }
-    }
-
-    return cv::Mat(rows, cols, CV_8UC1, gray);
-}*/
-
 static auto convert2Grayscale(cv::Mat& refData, size_t refCols, size_t refRows, ColorSpace colorSpace) {
     cv::Mat refGray;
 

--- a/WebARKit/include/WebARKitManager.h
+++ b/WebARKit/include/WebARKitManager.h
@@ -92,8 +92,6 @@ class WebARKitManager {
 
     bool initTracker(uchar* refData, size_t refCols, size_t refRows, ColorSpace colorSpace);
 
-    bool update();
-
     void setLogLevel(int logLevel);
 
     bool shutdown();


### PR DESCRIPTION
First (and minimal) cleanup from the #50 audit. **Behavior-neutral** — only a dead declaration and commented-out text are removed, so the compiled WASM is byte-identical (no rebuild needed). Three commits:

1. **`WebARKitManager::update()`** — declared in the header but never defined or called (the live per-frame path is `processFrameData()`). It only linked because nothing referenced it. Removed.
2. **`im_gray()`** — a fully commented-out grayscale routine in `WebARKitUtils.h`, superseded by `convert2Grayscale()`. Removed.
3. **Commented `_trackables[…]` / `getPoseMatrix3` lines** — the old multi-marker forms left beside their live single-marker replacements, plus the commented `getPoseMatrix3` decls. Removed; live code and explanatory comments untouched (brace balance verified 135/135).

## Scope note (per audit discussion)

After cross-checking ArtoolkitX OCVT, we **deliberately kept** everything with plausible future value rather than chasing maximal deletion:
- OCVT-derived symbols (`CleanUp` — used by ArtoolkitX `RemoveAllMarkers`; `GetAllFeatures`, `IsSelected`, `markerRoi`, `inlier_matches`) — kept for parity / possible future use.
- `_trackVizActive` / `TrackerVisualization` — kept as scaffolding for a future debug overlay.
- WebARKit accessors / alt-API / version / config constants (`getWebARKitVersion`, `getTracker`, `getDistortionCoefficients`, the cv::Mat overloads, the BCD version API, `N`, `featureDetectPyramidLevel`) — kept as plausible API surface.

So this PR removes only un-restorable-value noise. The KEEP decisions are being recorded in the companion webarkit-testing audit doc.

Refs #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)