### PR TITLE
refactor(#50): remove superseded computePose / invertPose / computeGLviewMatrix()

### DIFF
--- a/WebARKit/WebARKitPattern.cpp
+++ b/WebARKit/WebARKitPattern.cpp
@@ -22,11 +22,10 @@ void WebARKitPatternTrackingInfo::cameraPoseFromPoints(cv::Mat& pose, const std:
 
     // WebARKitLib#55: also populate pose3d -- the raw 4x4 OpenCV-convention camera
     // pose returned by getPoseMatrixCV(). The live path previously left pose3d at its
-    // zero-initialised value (only the now-dead computePose wrote it), so
-    // getPoseMatrixCV() returned an all-zero matrix. Build it here from the same
-    // rMat/tvec the GL path uses, so the CV and GL getters both reflect the current
-    // frame. No handedness/scale correction is applied (that is getPoseMatrixGL's
-    // trans); pose3d stays in raw OpenCV convention.
+    // zero-initialised value, so getPoseMatrixCV() returned an all-zero matrix. Build
+    // it here from the same rMat/tvec the GL path uses, so the CV and GL getters both
+    // reflect the current frame. No handedness/scale correction is applied (that is
+    // getPoseMatrixGL's trans); pose3d stays in raw OpenCV convention.
     for (int row = 0; row < 3; ++row) {
         for (int col = 0; col < 3; ++col) {
             pose3d.at<double>(row, col) = rMat.at<double>(row, col);
@@ -35,30 +34,6 @@ void WebARKitPatternTrackingInfo::cameraPoseFromPoints(cv::Mat& pose, const std:
     }
     pose3d.at<double>(3, 3) = 1.0;
 };
-
-void WebARKitPatternTrackingInfo::computePose(std::vector<cv::Point3f>& treeDPoints,
-                                              std::vector<cv::Point2f>& imgPoints, const cv::Matx33f& caMatrix,
-                                              const cv::Mat& distCoeffs) {
-    // cv::Mat rvec = cv::Mat::zeros(3, 1, CV_64FC1); // output rotation vector
-    // cv::Mat tvec = cv::Mat::zeros(3, 1, CV_64FC1); // output translation vector
-    cv::Mat rvec, tvec;
-
-    cv::solvePnPRansac(treeDPoints, imgPoints, caMatrix, distCoeffs, rvec, tvec);
-
-    cv::Mat rMat;
-    cv::Rodrigues(rvec, rMat);
-    // cv::hconcat(rMat, tvec, pose3d);
-
-    for (unsigned int row = 0; row < 3; ++row) {
-        for (unsigned int col = 0; col < 3; ++col) {
-            pose3d.at<double>(row, col) = rMat.at<double>(row, col);
-        }
-        pose3d.at<double>(row, 3) = tvec.at<double>(row, 0);
-    }
-    pose3d.at<double>(3, 3) = 1.0f;
-
-    invertPose();
-}
 
 void WebARKitPatternTrackingInfo::getTrackablePose(cv::Mat& pose) {
     //float transMat [3][4];
@@ -92,28 +67,4 @@ void WebARKitPatternTrackingInfo::updateTrackable() {
     }
 }
 
-void WebARKitPatternTrackingInfo::computeGLviewMatrix() { cv::transpose(pose3d, glViewMatrix); }
-
 void WebARKitPatternTrackingInfo::computeGLviewMatrix(cv::Mat &pose) { cv::transpose(pose, glViewMatrix); }
-
-void WebARKitPatternTrackingInfo::invertPose() {
-
-    /*cv::Mat invertPose(3, 4, CV_64FC1);
-    for (auto j = 0; j < 3; j++) {
-        invertPose.at<double>(j, 0) = pose3d.at<double>(j, 0);
-        invertPose.at<double>(j, 1) = -pose3d.at<double>(j, 1);
-        invertPose.at<double>(j, 2) = -pose3d.at<double>(j, 2);
-        //invertPose.at<double>(j, 3) = pose3d.at<double>(j, 3) * m_scale * 0.001f * 1.64f;
-        invertPose.at<double>(j, 3) = pose3d.at<double>(j, 3);
-    }*/
-
-    cv::Mat cvToGl = cv::Mat::zeros(4, 4, CV_64F);
-    cvToGl.at<double>(0, 0) = 1.0f;
-    cvToGl.at<double>(1, 1) = -1.0f; // Invert the y axis
-    cvToGl.at<double>(2, 2) = -1.0f; // invert the z axis
-    cvToGl.at<double>(3, 3) = 1.0f;
-
-    pose3d = cvToGl * pose3d;
-
-    // pose3d = invertPose;
-}

--- a/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
+++ b/WebARKit/WebARKitTrackers/WebARKitOpticalTracking/WebARKitTracker.cpp
@@ -441,7 +441,6 @@ class WebARKitTracker::WebARKitTrackerImpl {
             // leaving these empty. Skip pose estimation in that case.
             if (imgPoints.size() >= 4 && imgPoints.size() == objPoints.size()) {
                 _patternTrackingInfo.cameraPoseFromPoints(_pose, objPoints, imgPoints, m_camMatrix, m_distortionCoeff);
-                // _patternTrackingInfo.computePose(_pattern.points3d, warpedCorners, m_camMatrix, m_distortionCoeff);
                 _patternTrackingInfo.getTrackablePose(_pose);
                 _patternTrackingInfo.updateTrackable();
                 _patternTrackingInfo.computeGLviewMatrix(_pose);

--- a/WebARKit/include/WebARKitPattern.h
+++ b/WebARKit/include/WebARKitPattern.h
@@ -35,23 +35,14 @@ class WebARKitPatternTrackingInfo {
 
     void cameraPoseFromPoints(cv::Mat& pose, const std::vector<cv::Point3f>& objPts, const std::vector<cv::Point2f>& imgPts, const cv::Matx33f& caMatrix, const cv::Mat& distCoeffs);
 
-    /**
-     * Compute pattern pose using PnP algorithm
-     */
-    void computePose(std::vector<cv::Point3f>& treeDPoints, std::vector<cv::Point2f>& imgPoints, const cv::Matx33f& caMatrix,
-                     const cv::Mat& distCoeffs);
-
     void getTrackablePose(cv::Mat& pose);
 
     void updateTrackable();
-
-    void computeGLviewMatrix();
 
     void computeGLviewMatrix(cv::Mat &pose);
 
   private:
     float m_scale;
-    void invertPose();
 };
 
 #endif // WEBARKITPATTERN_H


### PR DESCRIPTION
Final #50 cleanup item (Tier 3). Removes WebARKit's own superseded pose-math, now fully replaced by `cameraPoseFromPoints` + the #55 `pose3d` fix.

## Removed
- **`computePose()`** — its only call site was already commented out; `cameraPoseFromPoints` is the live pose solve.
- **`invertPose()`** — only ever called by `computePose()`.
- **`computeGLviewMatrix()` (no-arg)** — uncalled; the live path uses the `computeGLviewMatrix(cv::Mat&)` overload (kept).
- the dangling commented `computePose` call in `WebARKitTracker.cpp`.

## Not ArtoolkitX-derived
Unlike the OCVT symbols we deliberately kept (`CleanUp`, `markerRoi`, etc.), these are WebARKit's *own* pose helpers, genuinely superseded — so removing them de-duplicates rather than diverging from upstream design.

## Compatibility
Behavior-neutral. The live pose/GL-view path (`cameraPoseFromPoints` → `getTrackablePose` → `updateTrackable` → `computeGLviewMatrix(cv::Mat&)`) is untouched; `pose3d` is still populated by `cameraPoseFromPoints` (#55). Brace balance verified.

Refs #50. After this, the #50 audit is complete (everything else was decided KEEP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)